### PR TITLE
Fixing crypto require for 4.0.3 version of decimal

### DIFF
--- a/decimal.js
+++ b/decimal.js
@@ -4046,7 +4046,7 @@
         if ( !crypto ) {
 
             try {
-                crypto = require('crypto');
+                crypto = require('cry' + 'pto');
             } catch (e) {}
         }
 


### PR DESCRIPTION
Unable to migrate to 5.x right now, so hoping that 4.0.4 can support the new way to require crypto 
