### PR TITLE
Heavier-handed `require` detection buster

### DIFF
--- a/decimal.js
+++ b/decimal.js
@@ -4780,7 +4780,8 @@
 
     if (!cryptoObject) {
       try {
-        cryptoObject = require('cry' + 'pto');
+        var pto = 'pto';
+        cryptoObject = require('cry' + pto);
       } catch (e) {
         // Ignore.
       }


### PR DESCRIPTION
React Native is using Babel/Babylon to [break constants up](https://github.com/facebook/react-native/blob/0b2d5317c419a78f2068437c18a0bf54c0ef325d/packager/react-packager/src/JSTransformer/worker/index.js#L34-L42) via AST parsing, so that the previous method to thwart `require` in packagers isn't enough anymore. 

I think ultimately this is a React Native packager problem, but there's a lot more complexity (and more use cases) on their side, so I think it's best just to address it here, so let's go with it?