### PR TITLE
remove abandoned character

### DIFF
--- a/decimal.d.ts
+++ b/decimal.d.ts
@@ -80,7 +80,7 @@ interface DecimalConfig {
 
 // Requires `toFormat`.
 interface DecimalFormat {
-  decimalSeparator?: string;s
+  decimalSeparator?: string;
   groupSeparator?: string;
   groupSize?: number;
   secondaryGroupSize?: number;


### PR DESCRIPTION
Many thanks for providing type definitions. Unfortunately a little character slipped into the v7.5 release. This pull request just removes this character.