### PR TITLE
Error for call constructor from Number.prototype.anyMethod, and Keyword 'for' on IE8

### DIFF
--- a/decimal.js
+++ b/decimal.js
@@ -4854,7 +4854,7 @@
   // Node and other environments that support module.exports.
   } else if (typeof module != 'undefined' && module.exports) {
     if (typeof Symbol == 'function' && typeof Symbol.iterator == 'symbol') {
-      P[Symbol.for('nodejs.util.inspect.custom')] = P.toString;
+      P[Symbol['for']('nodejs.util.inspect.custom')] = P.toString;
       P[Symbol.toStringTag] = 'Decimal';
     }
 

--- a/decimal.js
+++ b/decimal.js
@@ -4289,7 +4289,7 @@
 
       t = typeof v;
 
-      if (t === 'number') {
+      if (t === 'number' || v instanceof Number) {
         if (v === 0) {
           x.s = 1 / v < 0 ? -1 : 1;
           x.e = 0;


### PR DESCRIPTION
1. Symbol.for can't work on the IE8, changed to Symbol['for']
2. Error for call constructor from Number.prototype.anyMethod
```javascript
// Expect to use Decimal.prototype.toFixed replace the original method
(function() {
    var originalToFixed = Number.prototype.toFixed;
    Number.prototype.toFixed = function(decimal) {
        if (window.Decimal && Decimal.prototype.toFixed) { 
            return new Decimal(this).toFixed(decimal);
        } else {
            return originalToFixed(this, decimal);
        }
    };
)();
```
TestCode
(2).toFixed(2); 
will be run to line 4340 thrown error '[DecimalError] Invalid argument: 2'
because line 4290 test typeof v returned 'object'
if (t === 'number') changed to if (t === 'number' || v instanceof Number)