### PR TITLE
Use type predicate on isDecimal

### DIFF
--- a/decimal.d.ts
+++ b/decimal.d.ts
@@ -251,7 +251,7 @@ export declare class Decimal {
   static exp(n: Decimal.Value): Decimal;
   static floor(n: Decimal.Value): Decimal;
   static hypot(...n: Decimal.Value[]): Decimal;
-  static isDecimal(object: any): boolean
+  static isDecimal(object: any): object is Decimal;
   static ln(n: Decimal.Value): Decimal;
   static log(n: Decimal.Value, base?: Decimal.Value): Decimal;
   static log2(n: Decimal.Value): Decimal;

--- a/decimal.global.d.ts
+++ b/decimal.global.d.ts
@@ -272,7 +272,7 @@ export declare class Decimal {
   static exp(n: DecimalValue): Decimal;
   static floor(n: DecimalValue): Decimal;
   static hypot(...n: DecimalValue[]): Decimal;
-  static isDecimal(object: any): boolean
+  static isDecimal(object: any): object is Decimal;
   static ln(n: DecimalValue): Decimal;
   static log(n: DecimalValue, base?: DecimalValue): Decimal;
   static log2(n: DecimalValue): Decimal;


### PR DESCRIPTION
[Type Predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) help to narrow down types. Before this change:

```typescript
const value: Decimal | string = "123";

if (Decimal.isDecimal(value)) {
  // do something
} else {
  // Typescript still thinks value can be a Decimal or string
}
```

After:

```typescript
const value: Decimal | string = "123";

if (Decimal.isDecimal(value)) {
  // do something
} else {
  // Typescript now knows value is a string
}
```