### PR TITLE
Fix typescript 4.7 / node16 import/type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,15 @@
   "main": "decimal",
   "module": "decimal.mjs",
   "browser": "decimal.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./decimal.d.ts",
+        "default": "./decimal.mjs"
+      },
+      "require": "./decimal.js"
+    }
+  },
   "author": {
     "name": "Michael Mclaughlin",
     "email": "M8ch88l@gmail.com"


### PR DESCRIPTION
Typescript 4.7 / node16 uses decimal.js even is type is "module" because it does not find an export and uses main. If you directly include decimal.mjs then it tries to include decimal.d.mts and fails (no typing).