### PR TITLE
Remove toStringTag declaration for type compatibility

### DIFF
--- a/decimal.d.ts
+++ b/decimal.d.ts
@@ -56,7 +56,6 @@ export declare class Decimal {
   readonly d: number[];
   readonly e: number;
   readonly s: number;
-  private readonly toStringTag: string;
 
   constructor(n: Decimal.Value);
 

--- a/decimal.global.d.ts
+++ b/decimal.global.d.ts
@@ -77,7 +77,6 @@ export declare class Decimal {
   readonly d: number[];
   readonly e: number;
   readonly s: number;
-  private readonly toStringTag: string;
 
   constructor(n: DecimalValue);
 


### PR DESCRIPTION
- Allows `Decimal` type to be type compatible with multiple Decimal.js imports
- Resolves: https://github.com/prisma/prisma/issues/16397

The goal here is to handle multiple imports of Decimal.js and allow the `Decimal` type from each import to be used interchangeably.  `toStringTag` in the TypeScript declarations is the only thing preventing that.  I've verified that this resolves the linked issue (once Prisma is rebuilt with this Decimal.js change).