### PR TITLE
Create Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+Please disclose it at [security advisory](https://github.com/MikeMcl/decimal.js/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Closes #226 

I created the SECURITY.md file considering GitHub's new feature, [report vulnerability through security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).

If you want to use this GitHub feature, you must first [activate it for the repository](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository):

1. Access the "Code security & analysis" settings  by the following link https://github.com/MikeMcl/decimal.js/settings/security_analysis.
2. Click Enable for Private vulnerability reporting (Beta).

If you don't want to enable it, you can also receive the vulnerability report by email. In that case, just let me know what email address to use, and I'll submit the change.

Feel free to edit or suggest any changes to this document. It should reflect the amount of effort you can offer to handle vulnerabilities.
